### PR TITLE
Changes to AptStepMaker::GetToolIdentifier and AptStepMaker::GetToolId

### DIFF
--- a/src/nodeAptStepMaker.cpp
+++ b/src/nodeAptStepMaker.cpp
@@ -51,7 +51,7 @@ NAN_MODULE_INIT(AptStepMaker::Init)
     tpl->SetClassName(Nan::New("AptStepMaker").ToLocalChecked());
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-    Nan::SetPrototypeMethod(tpl, "GetToolId", GetToolId);
+    Nan::SetPrototypeMethod(tpl, "GetToolEID", GetToolEID);
     Nan::SetPrototypeMethod(tpl, "GetToolIdentifier", GetToolIdentifier);
     Nan::SetPrototypeMethod(tpl, "GetToolNumber", GetToolNumber);
     Nan::SetPrototypeMethod(tpl, "OpenProject", OpenProject);
@@ -63,7 +63,7 @@ NAN_MODULE_INIT(AptStepMaker::Init)
 
 }
 
-NAN_METHOD(AptStepMaker::GetToolId)
+NAN_METHOD(AptStepMaker::GetToolEID)
 {
     AptStepMaker * apt = Nan::ObjectWrap::Unwrap<AptStepMaker>(info.This());
     if (apt == 0) //Throw exception
@@ -72,12 +72,12 @@ NAN_METHOD(AptStepMaker::GetToolId)
 	return;
     if (!info[0]->IsString())
 	return;
-    char * tlNum = 0;
-    size_t tlNumLength = v8StringToChar(info[0], tlNum);
-    int tl_id;
-    if (!apt->_apt->get_tool_id(tlNum, tl_id)) //TODO: Handle error
+    char * toolNum = 0;
+    size_t toolNumLen = v8StringToChar(info[0], toolNum);
+    int toolEID;
+    if (!apt->_apt->get_tool_id(toolNum, toolEID)) //TODO: Handle error
 	return;
-    info.GetReturnValue().Set(tl_id);
+    info.GetReturnValue().Set(toolEID);
     return;
 }
 

--- a/src/nodeAptStepMaker.cpp
+++ b/src/nodeAptStepMaker.cpp
@@ -52,6 +52,7 @@ NAN_MODULE_INIT(AptStepMaker::Init)
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
     Nan::SetPrototypeMethod(tpl, "GetToolId", GetToolId);
+    Nan::SetPrototypeMethod(tpl, "GetToolIdentifier", GetToolIdentifier);
     Nan::SetPrototypeMethod(tpl, "GetToolNumber", GetToolNumber);
     Nan::SetPrototypeMethod(tpl, "OpenProject", OpenProject);
     Nan::SetPrototypeMethod(tpl, "SaveAsModules", SaveAsModules);
@@ -77,6 +78,24 @@ NAN_METHOD(AptStepMaker::GetToolId)
     if (!apt->_apt->get_tool_id(tlNum, tl_id)) //TODO: Handle error
 	return;
     info.GetReturnValue().Set(tl_id);
+    return;
+}
+
+NAN_METHOD(AptStepMaker::GetToolIdentifier)
+{
+    AptStepMaker * apt = Nan::ObjectWrap::Unwrap<AptStepMaker>(info.This());
+    if (apt == 0) //Throw Exception
+	return;
+    if (info.Length() != 1) //Function should get one argument.
+	return;
+    if (!info[0]->IsString())
+	return;
+    char * toolNum = 0;
+    size_t toolNumLength = v8StringToChar(info[0], toolNum);
+    const char * toolID = 0;
+    if (!apt->_apt->get_tool_identifier(toolNum, toolID)) // TODO: Handle error
+	return;
+    info.GetReturnValue().Set(CharTov8String((char *)toolNum));
     return;
 }
 

--- a/src/nodeAptStepMaker.h
+++ b/src/nodeAptStepMaker.h
@@ -35,8 +35,8 @@ public:
     static apt2step* getApt();
     static NAN_MODULE_INIT(Init);
 
-    //int GetToolId(string tool_number)
-    static NAN_METHOD(GetToolId);
+    //int GetToolEID(string tool_number)
+    static NAN_METHOD(GetToolEID);
 
     //string GetToolIdentifier(string tool_number)
     static NAN_METHOD(GetToolIdentifier);

--- a/src/nodeAptStepMaker.h
+++ b/src/nodeAptStepMaker.h
@@ -37,8 +37,13 @@ public:
 
     //int GetToolId(string tool_number)
     static NAN_METHOD(GetToolId);
+
+    //string GetToolIdentifier(string tool_number)
+    static NAN_METHOD(GetToolIdentifier);
+
     //string GetToolNumber(int id)
     static NAN_METHOD(GetToolNumber);
+
     static NAN_METHOD(OpenProject);
 
     //void SaveAsModules(v8::String file_name);


### PR DESCRIPTION
Implemented AptStepMaker::GetToolIdentifier. Currently unsure of the difference between tool identifier and tool number. As such, tests may be incorrect but implementation matches source code.
Changed AptStepMaker::GetToolId to AptStepMaker::GetToolEID as it returns the tool's entity id, not its identifier. Also edited references in code to reflect this change.
